### PR TITLE
Sanitize export selection input

### DIFF
--- a/smile-selective-export/smile-selective-export.php
+++ b/smile-selective-export/smile-selective-export.php
@@ -62,8 +62,10 @@ function smslxpt_handle_export_download() {
 		wp_die( esc_html__( 'Security check failed.', 'smile-selective-export' ) );
 	}
 
-	$selected = isset( $_POST['smslxpt_pages'] ) ? (array) $_POST['smslxpt_pages'] : array();
-	$page_ids = array();
+$selected_raw = isset( $_POST['smslxpt_pages'] ) ? wp_unslash( $_POST['smslxpt_pages'] ) : array();
+$selected_raw = is_array( $selected_raw ) ? $selected_raw : array( $selected_raw );
+$selected      = array_map( 'absint', $selected_raw );
+$page_ids = array();
 
 	foreach ( $selected as $id ) {
 		$id = absint( $id );


### PR DESCRIPTION
## Summary
- ensure the export handler unslashes and sanitizes the selected page IDs from POST data before use

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df8079756883309b9176350aa9b959