### PR TITLE
Add license metadata to plugin header

### DIFF
--- a/smile-selective-export/smile-selective-export.php
+++ b/smile-selective-export/smile-selective-export.php
@@ -4,6 +4,8 @@
  * Description: Export selected pages with their synced patterns (wp_block) and referenced media into a JSON package.
  * Version: 1.0.2
  * Author: Smile
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: smile-selective-export
  *
  * @package smile-selective-export


### PR DESCRIPTION
## Summary
- add GPL license metadata to the SMiLE Selective Export plugin header so it complies with WordPress.org requirements

## Testing
- ~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs --standard=WordPress-Extra smile-selective-export/smile-selective-export.php

------
https://chatgpt.com/codex/tasks/task_e_68df8c66ff24833086ae012fbc23b6bb