### PR TITLE
Add license metadata to plugin header

### DIFF
--- a/smile-assisted-import/smile-assisted-import.php
+++ b/smile-assisted-import/smile-assisted-import.php
@@ -4,6 +4,8 @@
  * Description: Import pages and their synced patterns from a SMiLE JSON package, download attachments, and rewrite URLs.
  * Version: 1.0.2
  * Author: Smile
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: smile-assisted-import
  *
  * @package smile-assisted-import


### PR DESCRIPTION
## Summary
- add GPL license name and URI to the SMiLE Assisted Import plugin header metadata

## Testing
- ~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs --standard=WordPress --extensions=php smile-assisted-import/smile-assisted-import.php

------
https://chatgpt.com/codex/tasks/task_e_68df8e343a6083309a6cb1bc3e6ea70a