### PR TITLE
Remove forbidden tag from plugin readme

### DIFF
--- a/smile-assisted-import/readme.txt
+++ b/smile-assisted-import/readme.txt
@@ -1,6 +1,6 @@
 === SMiLE Assisted Import ===
 Contributors: smilecomunicacion
-Tags: import, migration, patterns, media, wordpress
+Tags: import, migration, patterns, media
 Requires at least: 6.3
 Tested up to: 6.8
 Stable tag: 1.0.2


### PR DESCRIPTION
## Summary
- remove the forbidden `wordpress` keyword from the plugin readme tag list to comply with WordPress.org guidelines

## Testing
- Attempted `npx @wordpress/readme-validator smile-assisted-import/readme.txt` *(fails: package not found in npm registry via current proxy configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68df93f821d88330a396d4ae9fdf7a6c