### PR TITLE
Add short description to SMiLE Assisted Import readme

### DIFF
--- a/smile-assisted-import/readme.txt
+++ b/smile-assisted-import/readme.txt
@@ -1,4 +1,5 @@
 === SMiLE Assisted Import ===
+Automates SMiLE package imports with media handling, URL rewriting, and synced pattern remapping.
 Contributors: smilecomunicacion
 Tags: import, migration, patterns, media
 Requires at least: 6.3


### PR DESCRIPTION
## Summary
- add a concise short description line beneath the SMiLE Assisted Import readme heading

## Testing
- npx @wordpress/readme --path=readme.txt --validate *(fails: package not found in npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68df957e73448330a43b656fefe92ba1